### PR TITLE
Managing posterior mean samples

### DIFF
--- a/src/+LFADS/+Utils/loadPosteriorMeans.m
+++ b/src/+LFADS/+Utils/loadPosteriorMeans.m
@@ -5,9 +5,8 @@ function pms = loadPosteriorMeans(validFile, trainFile, validInds, ...
 
 total_trials = numel(validInds) + numel(trainInds);
 
-outputFields = {'controller_outputs','rates','factors', 'rates', 'generator_states', 'generator_ics'};
-storedVariables = {'controller_outputs','output_dist_params','factors', ...
-                   'rates', 'gen_states', 'gen_ics'};
+outputFields = {'controller_outputs','factors', 'rates', 'generator_states', 'generator_ics','costs','nll_bound_vaes','nll_bound_iwaes'};
+storedVariables = {'controller_outputs','factors','output_dist_params', 'gen_states', 'gen_ics','costs','nll_bound_vaes','nll_bound_iwaes'};
 
 tfInfo = h5info(trainFile);
 tfNames = {tfInfo.Datasets.Name};
@@ -27,7 +26,15 @@ for nf = 1:numel(vars_to_get)
     train.(outputName) = h5read(trainFile, sprintf('/%s',variable));
     
     % put them in the correct order
-    if ismember(variable, {'gen_ics'})
+    if ismember(variable, {'costs','nll_bound_vaes','nll_bound_iwaes'})
+        % trials on dim 1
+        has_valid = size(valid.(outputName),1);
+        has_train = size(train.(outputName),1);
+    
+        pms.(outputName) = nan(1, total_trials);
+        pms.(outputName)(1,validInds(1:has_valid)) = valid.(outputName);
+        pms.(outputName)(1,trainInds(1:has_train)) = train.(outputName);
+    elseif ismember(variable, {'gen_ics'})
         % 2d, trials on dim 2
         has_valid = size(valid.(outputName),2);
         has_train = size(train.(outputName),2);
@@ -37,6 +44,7 @@ for nf = 1:numel(vars_to_get)
         pms.(outputName)(:,validInds(1:has_valid)) = valid.(outputName);
         pms.(outputName)(:,trainInds(1:has_train)) = train.(outputName);
     else
+        % 3d, trials on dim 3
         has_valid = size(valid.(outputName),3);
         has_train = size(train.(outputName),3);
     

--- a/src/+LFADS/PosteriorMeans.m
+++ b/src/+LFADS/PosteriorMeans.m
@@ -8,7 +8,10 @@ classdef PosteriorMeans
         factors % `nFactors x T x nTrials` factor trajectories
         generator_ics % nGeneratorUnits x nTrials` generator initial conditions
         generator_states % nGeneratorUnits x T x nTrials 
-        rates % nNeurons x T x nTrials
+        rates % nNeurons x T x nTrials        
+        costs % 1 x nTrials
+        nll_bound_vaes % 1 x nTrials
+        nll_bound_iwaes % 1 x nTrials
         validInds % list of validation trial indices
         trainInds % list of training trial indices
         params % :ref:`LFADS_RunParams` instance
@@ -49,6 +52,11 @@ classdef PosteriorMeans
                 
                 % convert rates into spikes / sec
                 pm.rates = pms.rates * 1000 / params.spikeBinMs;
+                
+                pm.costs  = pms.costs;
+                pm.nll_bound_vaes = pms.nll_bound_vaes;
+                pm.nll_bound_iwaes = pms.nll_bound_iwaes;
+                
                 pm.validInds = pms.validInds;
                 pm.trainInds = pms.trainInds;
                 pm.time = time;

--- a/src/+LFADS/Run.m
+++ b/src/+LFADS/Run.m
@@ -1145,8 +1145,11 @@ classdef Run < handle & matlab.mixin.CustomDisplay
                 cmd = sprintf('%s $(which run_lfads.py) %s', execstr, optstr);
             else
                 % use the RunParams to generate the params
-                paramsString = r.params.generateCommandLineOptionsString(r, 'omitFields', {'c_temporal_spike_jitter_width', 'batch_size'});
-
+                paramsString = r.params.generateCommandLineOptionsString(r, 'omitFields', {'c_temporal_spike_jitter_width', 'c_batch_size'});
+                % mattgolub 12/6/2017: changed 'batch_size' above to
+                % 'c_batch_size'. This fixes the duplicated --batch_size
+                % flag in the command generated below.
+                
                 cmd = sprintf(['python $(which run_lfads.py) --data_dir=%s --data_filename_stem=lfads ' ...
                 '--lfads_save_dir=%s --kind=posterior_sample_and_average --batch_size=%d --checkpoint_pb_load_name=checkpoint_lve %s'], ...
                 LFADS.Utils.GetFullPath(r.pathLFADSInput), LFADS.Utils.GetFullPath(r.pathLFADSOutput), batchSize, paramsString);


### PR DESCRIPTION
--Fixed batch_size duplication in shell script generation for posterior mean sampling
--Added additional fields to be loaded into posterior means
--Fixed attempt to load 'rates' variable which does not exist in h5 posterior mean files